### PR TITLE
ci: bump nodejs version to 16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@v1
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: npm install
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: "The installed Apache Hadoop version."
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'star'


### PR DESCRIPTION
1. bump checkout@v2 to checkout@v3
2. bump setup-node@v1 to setup-node@v3
3. set nodejs version to 16.x

Signed-off-by: 蔡略 <cailue@bupt.edu.cn>